### PR TITLE
Allow Node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "main": "./lib/poppler.js",
   "engines": {
-    "node": ">=0.8.0 <0.14.0"
+    "node": ">=0.8.0"
   },
   "dependencies": {
     "nan": "^2.0.9"


### PR DESCRIPTION
I ran the tests on Node 4.1.2 and they all passed, so I think this is all that is needed to allow using `poppler-simple` with Node 4. Let me know if there is anything else that needs to be done.