### PR TITLE
Added rawOrder option to getWordList.

### DIFF
--- a/src/NodePopplerPage.cc
+++ b/src/NodePopplerPage.cc
@@ -214,11 +214,13 @@ namespace node {
         TextPage *text;
         TextWordList *wordList;
 
+        GBool rawOrder = info[0]->IsBoolean() ? (Nan::To<bool>(info[0]).FromMaybe(false) ? gTrue : gFalse) : gFalse;
+
         if (self->isDocClosed()) {
             return Nan::ThrowError("Document closed. You must delete this page");
         }
 
-        text = self->getTextPage();
+        text = self->getTextPage(rawOrder);
         wordList = text->makeWordList(gTrue);
         int l = wordList->getLength();
         Local<v8::Array> v8results = Nan::New<v8::Array>(l);
@@ -279,7 +281,7 @@ namespace node {
         String::Utf8Value str(info[0]);
 
         iconv_string("UCS-4LE", "UTF-8", *str, *str+strlen(*str)+1, &ucs4, &ucs4_len);
-        text = self->getTextPage();
+        text = self->getTextPage(gFalse);
 
         while (text->findText((unsigned int *)ucs4, ucs4_len/4 - 1,
                  gFalse, gTrue, // startAtTop, stopAtBottom

--- a/src/NodePopplerPage.h
+++ b/src/NodePopplerPage.h
@@ -153,12 +153,12 @@ namespace node {
     private:
         static NAN_GETTER(paramsGetter);
 
-        TextPage *getTextPage() {
+        TextPage *getTextPage(GBool rawOrder) {
             if (text == NULL) {
                 TextOutputDev *textDev;
                 Gfx *gfx;
 #if (POPPLER_VERSION_MINOR < 19)
-                textDev = new TextOutputDev(NULL, gTrue, gFalse, gFalse);
+                textDev = new TextOutputDev(NULL, gTrue, gFalse, rawOrder);
                 gfx = pg->createGfx(textDev, 72., 72., 0,
                     gFalse,
                     gTrue,
@@ -167,7 +167,7 @@ namespace node {
                     doc->getCatalog(),
                     NULL, NULL, NULL, NULL);
 #else
-                textDev = new TextOutputDev(NULL, gTrue, 0, gFalse, gFalse);
+                textDev = new TextOutputDev(NULL, gTrue, 0, rawOrder, gFalse);
                 gfx = pg->createGfx(textDev, 72., 72., 0,
                     gFalse,
                     gTrue,


### PR DESCRIPTION
This exposes the rawOrder option for `TextOutputDev` to `getWordList`. Some OCR systems don't order things correctly, this seems to resolve some of the issues.