### PR TITLE
Update for Poppler v22.01

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,6 +20,9 @@
             "cflags": [
                 "<!@(pkg-config --cflags poppler)"
             ],
+            "cflags_cc": [
+                "-std=c++17"
+            ],
             "defines": [
                 "NODE_VERSION_MAJOR=<(major_version)",
                 "NODE_VERSION_MINOR=<(minor_version)",
@@ -31,7 +34,8 @@
                         'OTHER_CFLAGS': [
                             "<!@(pkg-config --cflags poppler)",
                             "<!@(dirname -- `pkg-config --cflags poppler`)",
-                            "-stdlib=libc++"
+                            "-stdlib=libc++",
+                            "-std=c++17"
                         ],
                         "OTHER_LDFLAGS": [
                             "-liconv"
@@ -40,7 +44,7 @@
                 }],
                 ['OS!="win"', {
                     'cflags_cc+': [
-                        '-std=c++14',
+                        '-std=c++17',
                     ],
                 }],
             ],


### PR DESCRIPTION
Poppler 22.01 introduced a change wherein what were previously GooString* instances are now wrapped in an `std::optional`. This feature is only supported by C++17 and onwards.

This PR updates the build process to use C++17.